### PR TITLE
Pvt glevans esrf operation json fixes

### DIFF
--- a/mmcif_gen/operations/esrf/esrf_investigations.json
+++ b/mmcif_gen/operations/esrf/esrf_investigations.json
@@ -513,8 +513,8 @@
       {
         "reader": "json",
         "operation": "jq_filter",
-        "target_category": "_pdbx_fraghub_investigation_frag_component_mix",
-        "target_items": "fraglib_component_id",
+        "target_category": "_pdbx_ligscreen_investigation_lib_component_mix",
+        "target_items": "lib_component_id",
         "operation_parameters": {
           "jq": "[.campaigns[].crystals[].compounds[].id | tostring]"
         }
@@ -522,7 +522,7 @@
       {
         "reader": "json",
         "operation": "jq_filter",
-        "target_category": "_pdbx_fraghub_investigation_frag_component_mix",
+        "target_category": "_pdbx_ligscreen_investigation_lib_component_mix",
         "target_items": "id",
         "operation_parameters": {
           "jq": "[.campaigns[].crystals[] | .compounds[] | null]"


### PR DESCRIPTION
1. updated to:
`_pdbx_ligscreen_investigation_campaign`
from
`_pdbx_fraghub_investigation_campaign`

2. updated both category name and item names for:
`_pdbx_ligscreen_investigation_series`

3. Automated content for following items:
`_pdbx_ligscreen_investigation_series.lib_identification_method`
`_pdbx_ligscreen_investigation_series.library`
`_pdbx_ligscreen_investigation_series.type_of_library`

as
```
other
Other
OTHER
```

4. `_pdbx_fraghub_investigation_fraglib_component`
updated to:
`_pdbx_ligscreen_investigation_lib_component`


5. Updated category name
`_pdbx_fraghub_investigation_frag_component_mix`
to
`_pdbx_ligscreen_investigation_lib_component_mix`

6. Changed item from
`fraglib_component_id`
to
`lib_component_id`