### PR TITLE
Pvt glevans esrf operation json fixes

### DIFF
--- a/mmcif_gen/operations/esrf/esrf_investigations.json
+++ b/mmcif_gen/operations/esrf/esrf_investigations.json
@@ -47,7 +47,6 @@
         "target_items": ["type", "db", "external_url"],
         "target_values": ["Ligand Screening", "ligscreen", null],
         "operation": "static_value"
-        }
       },
       {
         "reader": "json",


### PR DESCRIPTION
## Updated esrf operation json

### _pdbx_ligscreen_investigation_campaign

`_pdbx_fraghub_investigation_campaign`
updated to:
`_pdbx_ligscreen_investigation_campaign`

### _pdbx_ligscreen_investigation_series

updated both category name and item names for:
`_pdbx_ligscreen_investigation_series`

added items and filled with static values:

- `lib_identification_method`
- `library`
- `type_of_library`
--> `other`, `Other`, `OTHER`

### _pdbx_ligscreen_investigation_lib_component

`_pdbx_fraghub_investigation_fraglib_component`
updated to:
`_pdbx_ligscreen_investigation_lib_component`

### _pdbx_ligscreen_investigation_lib_component_mix

`_pdbx_fraghub_investigation_frag_component_mix`
updated to:
`_pdbx_ligscreen_investigation_lib_component_mix`

item
`fraglib_component_id`
updated to:
`lib_component_id`

### _pdbx_ligscreen_investigation_screening_exp

`_pdbx_fraghub_investigation_screening_exp`
updated to:
`_pdbx_ligscreen_investigation_screening_exp`

added items and filled with static values:
- `exp_details`
- `exp_external_url`
- `instance_id`
--> `null` , `null` , `1`

### _pdbx_ligscreen_investigation_screening_result

`_pdbx_fraghub_investigation_screening_result`
updated to:
`_pdbx_ligscreen_investigation_screening_result`

### _pdbx_investigation

Update various items for category:
`_pdbx_investigation`

Values for details and title were swapped.
Project name was added to details.

added items and filled with static values:
- `type`
- `db`
- `external_url`
--> `Ligand Screening`, `ligscreen`, `null`

Item `project` does not exist, but `project_id` does
jq for id (originally outputted to `_pdbx_investigation.id`) was switch to be `project_id`

Added new code snippet for `_pdbx_investigation.id`.
New code give it a placeholder value of `I_54321`.

We need a way of generating this so **investigation ids** are assigned by us at EBI so that the same id is NOT assigned to 2 different investigations generated at 2 different facilities.

item called investigation id in various categories is no longer generated from json input but taken from the first instance of id aka value in `_pdbx_investigation.id`

### _pdbx_ligscreen_investigation_author

Removed categories:
`audit author`
`pdbx_contact_author`

add new category:
`_pdbx_ligscreen_investigation_author`
items:
`ordinal`
`campaign_id`
`investigation_id`
`name`